### PR TITLE
Added check for preexisting username / email

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -20,14 +20,22 @@ async function createAuth (accType, username, password){
 
 usersRouter.post('/businesses', async (request, response) => {
     // Post a new business user account
-    const { username, password } = request.body;
-    if (!password || !username) {
-      return response.status(400).json({ error: 'a username and password are required' });
-    }
 
-    const { businessName, address, zipCode, city, state, email, phoneNumber, availability } = request.body;
+    const { username, password, businessName, address, zipCode, city, state, email, phoneNumber, availability } = request.body;
+    
+    // checks for missing fields
     if (!businessName || !address || !zipCode || !city || !state || !email || !phoneNumber || !availability) {
       return response.status(400).json({ error: 'missing field(s) when creating a business account' });
+    }
+
+    // checks for existing username / email
+    const existingUser = await Authentication.findOne({ username });
+    if (existingUser) {
+      return response.status(400).json({ error: 'username already exists, please select another' });
+    }
+    const existingEmail = await Business.findOne({ email });
+    if (existingEmail) {
+      return response.status(400).json({ error: 'email is associated with existing account, please select another' });
     }
 
     const type = 'business'
@@ -54,14 +62,22 @@ usersRouter.post('/businesses', async (request, response) => {
 
 usersRouter.post('/customers', async (request, response) => {
   // Post a new customer user account
-  const { username, password } = request.body;
-  if (!password || !username) {
-    return response.status(400).json({ error: 'a username and password are required' });
-  }
 
-  const { firstName, lastName, address, zipCode, city, state, email, phoneNumber } = request.body;
+  const { username, password, firstName, lastName, address, zipCode, city, state, email, phoneNumber } = request.body;
+
+  // checks for missing fields
   if ( !firstName || !lastName || !address || !zipCode || !city || !state || !email || !phoneNumber) {
     return response.status(400).json({ error: 'missing field(s) when creating a customer account' });
+  }
+
+  // checks for existing username / email
+  const existingUser = await Authentication.findOne({ username });
+  if (existingUser) {
+    return response.status(400).json({ error: 'username already exists, please select another' });
+  }
+  const existingEmail = await Customer.findOne({ email });
+  if (existingEmail) {
+    return response.status(400).json({ error: 'email is associated with existing account, please select another' });
   }
 
   const type = 'customer'


### PR DESCRIPTION
Added check to make sure a new account cannot be created with the same username / email as a previous account
The order of checks is now -> missing fields | username | email | creation
The same testing format from before still works with formats:
customer
{
    "username": "a",
    "password": "b",
    "firstName": "c",
    "lastName": "d",
    "address": "e",
    "zipCode": "f",
    "city": "g",
    "state": "h",
    "email": "i",
    "phoneNumber": "j"
}
business
{
    "username": "A",
    "password": "B",
    "businessName": "C",
    "address": "D",
    "zipCode": "E",
    "city": "F",
    "state": "G",
    "email": "H",
    "phoneNumber": "I",
    "availability": [{
    "Monday": [{"start": "9:00", "end": "12:00"}],
    "Tuesday": [{"start": "9:00", "end": "12:00"}, {"start": "13:00", "end": "17:00"}]
}]
}